### PR TITLE
Update piwik.xml to use $this->data[...] for site search values

### DIFF
--- a/upload/vqmod/xml/piwik.xml
+++ b/upload/vqmod/xml/piwik.xml
@@ -84,7 +84,7 @@
 		// BOF - Piwik Opencart mod
 		$this->load->model('tool/piwik');
 		$this->session->data['last_search_total'] = $product_total;
-		$this->model_tool_piwik->trackSiteSearch($filter_name, $filter_category_id, $product_total);
+		$this->model_tool_piwik->trackSiteSearch($this->data['filter_name'], $this->data['filter_category_id'], $product_total);
 		// EOF - Piwik Opencart mod
 			]]></add>
 		</operation>


### PR DESCRIPTION
v1.5.4 saw the following errors in vqmod/vqcache/vq2-catalog_controller_product_search.php:
PHP Notice:  Undefined variable: filter_name
PHP Notice:  Undefined variable: filter_category_i

I have not tested later versions.
